### PR TITLE
Allow policy to set a default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ This policy rejects all the Pods that have at least one container or
 init container with the `allowPrivilegeEscalation` security context
 enabled.
 
+The policy can also mutate Pods to ensure they have `allowPrivilegeEscalation`
+set to `false` whenever the user is not explicit about that.
+This is a replacement of the `DefaultAllowPrivilegeEscalation` configuration
+option of the original Kubernetes PSP.
+
+# Configuration
+
+The policy can be configured in this way:
+
+```yaml
+default_allow_privilege_escalation: false
+```
+
+Sets the default for the allowPrivilegeEscalation option. The default behavior without this is to allow privilege escalation so as to not break setuid binaries. If that behavior is not desired, this field can be used to default to disallow, while still permitting pods to request allowPrivilegeEscalation explicitly.
+
+By default `default_allow_privilege_escalation` is set to `true`.
+
 # Examples
 
 The following Pod will be rejected because the nginx container has
@@ -52,6 +69,7 @@ spec:
     securityContext:
       allowPrivilegeEscalation: true
 ```
+
 # Obtain policy
 
 The policy is automatically published as an OCI artifact inside of

--- a/hub.yml
+++ b/hub.yml
@@ -13,5 +13,5 @@ keywords:
   - Privilege Escalation
 resources:
   - Pod
-mutation: false
+mutation: true
 contextAware: false

--- a/metadata.yml
+++ b/metadata.yml
@@ -3,7 +3,7 @@ rules:
     apiVersions: ["v1"]
     resources: ["pods"]
     operations: ["CREATE", "UPDATE"]
-mutating: false
+mutating: true
 contextAware: false
 annotations:
   io.kubewarden.policy.title: psp-allow-privilege-escalation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use anyhow::{anyhow, Result};
+
 extern crate wapc_guest as guest;
 use guest::prelude::*;
 
@@ -5,8 +7,8 @@ mod settings;
 use settings::Settings;
 
 use kubewarden_policy_sdk::{
-    accept_request, protocol_version_guest, reject_request, request::ValidationRequest,
-    validate_settings,
+    accept_request, mutate_request, protocol_version_guest, reject_request,
+    request::ValidationRequest, validate_settings,
 };
 
 use k8s_openapi::api::core::v1 as apicore;
@@ -18,39 +20,140 @@ pub extern "C" fn wapc_init() {
     register_function("protocol_version", protocol_version_guest);
 }
 
+#[derive(Debug, PartialEq)]
+enum PolicyResponse {
+    Accept,
+    Reject(String),
+    Mutate(serde_json::Value),
+}
+
 fn validate(payload: &[u8]) -> CallResult {
-    let validation_req = ValidationRequest::<Settings>::new(payload)?;
-    let pod = serde_json::from_value::<apicore::Pod>(validation_req.request.object)?;
+    let validation_request = ValidationRequest::<Settings>::new(payload)?;
+    let pod = match serde_json::from_value::<apicore::Pod>(validation_request.request.object) {
+        Ok(pod) => pod,
+        Err(_) => return accept_request(),
+    };
 
-    let any_allowed_privilege_escalation_container = pod
-        .spec
-        .map(|spec| {
-            has_allowed_privilege_escalation_container(spec.init_containers)
-                || has_allowed_privilege_escalation_container(Some(spec.containers))
-        })
-        .unwrap_or(false);
+    let settings = validation_request.settings;
 
-    if any_allowed_privilege_escalation_container {
-        reject_request(
-            Some(format!(
-                "User '{}' cannot create containers with allowPrivilegeEscalation enabled",
-                validation_req.request.user_info.username,
-            )),
-            None,
-        )
-    } else {
-        accept_request()
+    match do_validate(pod, settings)? {
+        PolicyResponse::Accept => accept_request(),
+        PolicyResponse::Reject(message) => reject_request(Some(message), None),
+        PolicyResponse::Mutate(mutated_object) => mutate_request(mutated_object),
     }
 }
 
-fn has_allowed_privilege_escalation_container(containers: Option<Vec<apicore::Container>>) -> bool {
-    containers.unwrap_or_default().into_iter().any(|container| {
+fn do_validate(pod: apicore::Pod, settings: settings::Settings) -> Result<PolicyResponse> {
+    if pod.spec.is_none() {
+        return Ok(PolicyResponse::Accept);
+    }
+    let pod_spec = pod.spec.unwrap();
+    let mut errors = vec![];
+
+    let mutated_init_containers: Option<Vec<apicore::Container>> =
+        match pod_spec.init_containers.clone() {
+            Some(init_containers) => {
+                if has_allowed_privilege_escalation_container(init_containers.clone()) {
+                    errors.push("one of the init containers has privilege escalation enabled");
+                    None
+                } else {
+                    patch_containers(init_containers, settings.default_allow_privilege_escalation)
+                }
+            }
+            None => None,
+        };
+
+    let mutated_containers: Option<Vec<apicore::Container>> =
+        if has_allowed_privilege_escalation_container(pod_spec.containers.clone()) {
+            errors.push("one of the containers has privilege escalation enabled");
+            None
+        } else {
+            patch_containers(
+                pod_spec.containers.clone(),
+                settings.default_allow_privilege_escalation,
+            )
+        };
+
+    if !errors.is_empty() {
+        return Ok(PolicyResponse::Reject(errors.join(", ")));
+    }
+
+    if mutated_containers.is_some() || mutated_init_containers.is_some() {
+        let init_containers = mutated_init_containers.or_else(|| pod_spec.init_containers.clone());
+        let containers = mutated_containers.unwrap_or_else(|| pod_spec.containers.clone());
+
+        let mutated_pod = apicore::Pod {
+            spec: Some(apicore::PodSpec {
+                init_containers,
+                containers,
+                ..pod_spec
+            }),
+            ..pod
+        };
+        let mutated_pod_value = serde_json::to_value(&mutated_pod)
+            .map_err(|e| anyhow!("Cannot build mutated pod response: {:?}", e))?;
+        Ok(PolicyResponse::Mutate(mutated_pod_value))
+    } else {
+        Ok(PolicyResponse::Accept)
+    }
+}
+
+fn has_allowed_privilege_escalation_container(containers: Vec<apicore::Container>) -> bool {
+    containers.into_iter().any(|container| {
         container
             .security_context
             .map_or(false, |security_context| {
                 security_context.allow_privilege_escalation.unwrap_or(false)
             })
     })
+}
+
+fn patch_containers(
+    containers: Vec<apicore::Container>,
+    default_allow_privilege_escalation: bool,
+) -> Option<Vec<apicore::Container>> {
+    if default_allow_privilege_escalation {
+        // the default behavior or Kubernetes is to allow privilege escalation
+        return None;
+    }
+
+    let mut mutations_done = false;
+    let new_containers: Vec<apicore::Container> = containers
+        .iter()
+        .map(|c| {
+            let new_sc = match c.security_context.clone() {
+                Some(sc) => {
+                    if sc.allow_privilege_escalation == Some(false) {
+                        sc
+                    } else {
+                        mutations_done = true;
+                        apicore::SecurityContext {
+                            allow_privilege_escalation: Some(false),
+                            ..sc
+                        }
+                    }
+                }
+                None => {
+                    mutations_done = true;
+                    apicore::SecurityContext {
+                        allow_privilege_escalation: Some(false),
+                        ..Default::default()
+                    }
+                }
+            };
+
+            apicore::Container {
+                security_context: Some(new_sc),
+                ..c.clone()
+            }
+        })
+        .collect();
+
+    if mutations_done {
+        Some(new_containers)
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]
@@ -65,11 +168,11 @@ mod tests {
         let tc = Testcase {
             name: String::from("Reject"),
             fixture_file: String::from(request_file),
-            settings: Settings {},
+            settings: Settings::default(),
             expected_validation_result: false,
         };
 
-        let _ = tc.eval(validate);
+        let _ = tc.eval(validate)?;
         Ok(())
     }
 
@@ -80,11 +183,11 @@ mod tests {
         let tc = Testcase {
             name: String::from("Accept"),
             fixture_file: String::from(request_file),
-            settings: Settings {},
+            settings: Settings::default(),
             expected_validation_result: false,
         };
 
-        let _ = tc.eval(validate);
+        let _ = tc.eval(validate)?;
         Ok(())
     }
 
@@ -94,11 +197,16 @@ mod tests {
         let tc = Testcase {
             name: String::from("Accept"),
             fixture_file: String::from(request_file),
-            settings: Settings {},
+            settings: Settings {
+                default_allow_privilege_escalation: false,
+            },
             expected_validation_result: true,
         };
 
-        let _ = tc.eval(validate);
+        let vr = tc.eval(validate)?;
+
+        // no need to mutate the object
+        assert!(vr.mutated_object.is_none());
         Ok(())
     }
 
@@ -108,11 +216,29 @@ mod tests {
         let tc = Testcase {
             name: String::from("Accept"),
             fixture_file: String::from(request_file),
-            settings: Settings {},
+            settings: Settings::default(),
             expected_validation_result: true,
         };
 
-        let _ = tc.eval(validate);
+        let _ = tc.eval(validate)?;
+        Ok(())
+    }
+
+    #[test]
+    fn mutate_pod_without_security_context() -> Result<()> {
+        let request_file = "test_data/req_pod_without_security_context.json";
+        let tc = Testcase {
+            name: String::from("Accept"),
+            fixture_file: String::from(request_file),
+            settings: Settings {
+                default_allow_privilege_escalation: false,
+            },
+            expected_validation_result: true,
+        };
+
+        let vr = tc.eval(validate)?;
+        assert!(vr.mutated_object.is_some());
+
         Ok(())
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,17 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct Settings {}
+pub(crate) struct Settings {
+    pub default_allow_privilege_escalation: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Settings {
+            default_allow_privilege_escalation: true,
+        }
+    }
+}
 
 impl kubewarden_policy_sdk::settings::Validatable for Settings {
     fn validate(&self) -> Result<(), String> {

--- a/test_data/req_pod_with_allowPrivilegeEscalation_disabled.json
+++ b/test_data/req_pod_with_allowPrivilegeEscalation_disabled.json
@@ -138,6 +138,9 @@
           "name": "sidecar",
           "image": "sidecar",
           "resources": {},
+          "securityContext": {
+            "allowPrivilegeEscalation": false
+          },
           "volumeMounts": [
             {
               "name": "default-token-pvpz7",


### PR DESCRIPTION
Turn the policy into a mutation one. The policy now has an optional configuaration value that allows the user to set the default value for `allowPrivilegeEscalation`.

This is required to fully implement the behaviour of the original Kubernetes PSP.

See https://github.com/kubewarden/allow-privilege-escalation-psp-policy/issues/7 for more details
