### PR TITLE
Allow empty settings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "kubewarden-policy-sdk",
  "serde",
  "serde_json",
+ "serde_yaml",
  "wapc-guest",
 ]
 
@@ -69,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
 name = "http"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +95,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -140,6 +157,12 @@ name = "libc"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "matches"
@@ -315,6 +338,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,3 +458,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ k8s-openapi = "0.11.0"
 serde_json = "1.0"
 wapc-guest = "0.4.0"
 kubewarden-policy-sdk = "0.2.2"
+
+[dev-dependencies]
+serde_yaml = "0.8.13"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(default)]
 pub(crate) struct Settings {
     pub default_allow_privilege_escalation: bool,
 }
@@ -15,6 +16,39 @@ impl Default for Settings {
 
 impl kubewarden_policy_sdk::settings::Validatable for Settings {
     fn validate(&self) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_yaml;
+
+    #[test]
+    fn test_policy_with_no_settings() -> Result<(), ()> {
+        let payload = "settings:";
+        let settings = serde_yaml::from_str::<Settings>(payload);
+        assert!(
+            settings.is_ok(),
+            "settings parse should not fails if it is empty"
+        );
+        assert!(
+            settings.unwrap().default_allow_privilege_escalation,
+            "default_allow_privilege_escalation should be 'true' when not defined by the user"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_policy_with_settings() -> Result<(), serde_yaml::Error> {
+        let payload = "default_allow_privilege_escalation: true";
+        let settings = serde_yaml::from_str::<Settings>(payload)?;
+        assert!(settings.default_allow_privilege_escalation);
+
+        let payload = "default_allow_privilege_escalation: false";
+        let settings = serde_yaml::from_str::<Settings>(payload)?;
+        assert_eq!(settings.default_allow_privilege_escalation, false);
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

The policy should allow the user leave the settings field empty. This was not working because serde_yaml tries to find all the fields unless we use the #[serde(default)]. This commit add this attribute to fix the issue and tests to ensure it's working as expected. 
Fix #9 
