### PR TITLE
feat: Add Rancher Helm chart folder

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -16,3 +16,19 @@ annotations:
     This policy works by inspecting the containers and init containers of a Pod.
 
     If any of these containers has `allowPrivilegeEscalation` enabled, the Pod is rejected.
+questions:
+  categories:
+  - security
+  namespace: kubewarden
+  questions:
+  - default: true
+    description: This policy works by inspecting the containers and init containers
+      of a Pod. If any of these containers have `allowPrivilegeEscalation` enabled,
+      the Pod will be rejected.
+    tooltip: Used to default to disallow, while still permitting pods to request allowPrivilegeEscalation
+      explicitly.
+    group: Settings
+    label: Allow privilege escalation
+    required: false
+    type: boolean
+    variable: default_allow_privilege_escalation

--- a/rancher-helm-chart/.helmignore
+++ b/rancher-helm-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+readme-dir.md

--- a/rancher-helm-chart/Chart.yaml
+++ b/rancher-helm-chart/Chart.yaml
@@ -1,0 +1,35 @@
+# This is a Helm Chart Chart.yaml file. Used to build a Rancher Helm chart.
+---
+apiVersion: v2
+name: allow-privilege-escalation-psp
+description: A Helm chart for deploying the allow-privilege-escalation-psp
+icon: https://www.kubewarden.io/images/icon-kubewarden.svg
+type: application
+home: https://www.kubewarden.io/
+kubeVersion: ">= 1.19.0"
+keywords:
+  - Security
+  - Infrastructure
+  - Monitoring
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.11
+
+appVersion: 0.1.11
+
+annotations:
+  # required ones:
+  catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
+  catalog.cattle.io/ui-component: kubewarden # This is added for custom UI deployment of a chart
+  catalog.cattle.io/os: linux   # this means linux only, other choice here is "windows". For charts that support both, don't add this annotation
+
+  # optional ones:
+  # catalog.cattle.io/requires-gvr: "policyservers.policies.kubewarden.io/v1" # Declare that this chart provides a type, which other charts may use in `requires-gvr`. Only add to parent, not CRD chart.
+
+  catalog.cattle.io/scope: management # Chart is only applicable to the management/local cluster and will be only shown as an option for the local cluster
+
+  # Valid values for the following annotation include: `cluster-tool`, `app` or `cluster-template`
+  # See the Cluster Tools section to learn more about when to set this value to `cluster-tool`.
+  catalog.cattle.io/type: cluster-tool

--- a/rancher-helm-chart/questions.yaml
+++ b/rancher-helm-chart/questions.yaml
@@ -1,0 +1,26 @@
+# This is a Rancher questions file
+---
+questions:
+- variable: settings.default_allow_privilege_escalation
+  type: boolean
+  default: true
+  required: true
+  group: Policy settings
+  description: This policy works by inspecting the containers and init containers
+    of a Pod. If any of these containers have `allowPrivilegeEscalation` enabled,
+    the Pod will be rejected.
+  tooltip: Used to default to disallow, while still permitting pods to request allowPrivilegeEscalation
+    explicitly.
+  label: Allow privilege escalation
+
+- variable: "kind"
+  type: string
+  default: "ClusterAdmissionPolicy"
+  required: true
+  group: Policy settings
+  description: This policy works by inspecting the containers and init containers
+    of a Pod. If any of these containers have `allowPrivilegeEscalation` enabled,
+    the Pod will be rejected.
+  tooltip: Used to default to disallow, while still permitting pods to request allowPrivilegeEscalation
+    explicitly.
+  label: Allow privilege escalation

--- a/rancher-helm-chart/readme-dir.md
+++ b/rancher-helm-chart/readme-dir.md
@@ -1,0 +1,1 @@
+This folder contains the needed files to build a Rancher Helm chart for this policy.

--- a/rancher-helm-chart/templates/policy.yaml
+++ b/rancher-helm-chart/templates/policy.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: policies.kubewarden.io/v1
+kind: {{ .Values.kind }}
+metadata:
+  name: {{ .Values.name }}
+  {{- if eq .Values.kind "AdmissionPolicy" }}
+  namespace: {{ .Values.namespace }}
+  {{- end }}
+spec:
+  module: '{{ .Values.policy_module.repository }}:{{ .Values.policy_module.tag }}'
+  settings:
+    {{ .Values.settings | toYaml }}
+  rules:
+    - apiGroups:
+        - ""
+      apiVersions:
+        - v1
+      resources:
+        - pods
+      operations:
+        - CREATE
+        - UPDATE
+  mutating: true

--- a/rancher-helm-chart/values.yaml
+++ b/rancher-helm-chart/values.yaml
@@ -1,0 +1,8 @@
+name: allow-privilege-escalation-psp
+kind: ClusterAdmissionPolicy
+namespace: default # used when kind is AdmissionPolicy
+policy_module:
+  repository: "registry://ghcr.io/kubewarden/policies/allow-privilege-escalation-psp"
+  tag: "v0.1.11"
+settings:
+  default_allow_privilege_escalation: true


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to  https://github.com/kubewarden/rfc/pull/12

The policy resource template is rendered completely from whatever Helm
values are passed. This is done by consuming everything in
`values.yaml`, and of course accepts `--set` to overwrite, expand, or
remove things that end in the template.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

To create an `AdmissionPolicy` instead of the default
`ClusterAdmissionPolicy`:
`helm template . --set kind="AdmissionPolicy"`

To set the policy as non-mutating:
`helm template . --set kind="AdmissionPolicy" --set mutating="false"`

And so on.

## Additional Information

### Tradeoff

See [RFC 10.](https://github.com/kubewarden/rfc/pull/12)
