### PR TITLE
High level resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "allow-privilege-escalation-psp"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "kubewarden-policy-sdk",
  "serde",
  "serde_json",
- "serde_yaml 0.9.2",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -63,11 +63,10 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -79,11 +78,10 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -135,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "kubewarden-policy-sdk"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4f07471a46151c3272d2ed0e3e62ecbae9b75ff374476c9468b54cd6b20a10"
+checksum = "3a723c2049fd9d9da5677bbee537d8444d7f447a6a010786bb4cc6403bfd0df1"
 dependencies = [
  "anyhow",
  "k8s-openapi",
@@ -146,7 +144,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "slog",
  "url",
  "wapc-guest",
@@ -157,12 +155,6 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -308,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "proc-macro2"
@@ -394,21 +386,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826f989c0f374733af6c286f4822f293bc738def07e2782dc1cbb899960a504a"
+checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
 dependencies = [
  "indexmap",
  "itoa 1.0.2",
@@ -481,19 +461,18 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc1c637311091be28e5d462c07db78081e5828da80ba22605c81c4ad6f7f813"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
  "serde",
 ]
@@ -529,12 +508,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 k8s-openapi = { version = "0.15.0", default_features = false, features = ["v1_24"] }
 serde_json = "1.0"
-kubewarden-policy-sdk = "0.6.3"
+kubewarden-policy-sdk = "0.8.0"
 
 [dev-dependencies]
 serde_yaml = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allow-privilege-escalation-psp"
-version = "0.1.11"
+version = "0.2.0"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ Sets the default for the allowPrivilegeEscalation option. The default behavior w
 
 By default `default_allow_privilege_escalation` is set to `true`.
 
+This policy can inspect Pod resources, but can also operate against "higher order"
+Kuberenetes resource like Deployment, ReplicaSet, DaemonSet, ReplicationController,
+Job and CronJob.
+
+It's up to the operator to decide which kind of resources the policy is going to inspect.
+That is done when declaring the policy.
+
+There are pros and cons to both approaches:
+
+- Have the policy inspect low level resources, like Pod. Different kind of Kubernetes
+  resources (be them native or CRDs) can create Pods. By having the policy target Pod
+  objects, there's the guarantee all the Pods are going to be compliant. However,
+  this could lead to some confusion among end users of the cluster: their high level
+  Kubernetes resources would be successfully created, but they would stay in a non
+  reconciled state. For example, a Deployment creating a non-compliant Pod would be
+  created, but it would never have all its replicas running. The end user would
+  have to do some debugging to finally understand why this is happening.
+- Have the policy inspect higher order resource (e.g. Deployment): the end users
+  will get immediate feedback about the rejections. However, there's still the
+  chance that some non compliant pods are created by another high level resource
+  (be it native to Kubernetes, or a CRD).
+
 # Examples
 
 The following Pod will be rejected because the nginx container has

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -1,5 +1,5 @@
 ---
-version: 0.1.11
+version: 0.2.0
 name: allow-privilege-escalation-psp
 displayName: Allow Privilege Escalation PSP
 createdAt: '2022-07-19T14:46:21+02:00'
@@ -8,14 +8,14 @@ license: Apache-2.0
 homeURL: https://github.com/kubewarden/allow-privilege-escalation-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.1.11
+  image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.2.0
 keywords:
 - psp
 - container
 - privilege escalation
 links:
 - name: policy
-  url: https://github.com/kubewarden/allow-privilege-escalation-psp-policy/releases/download/v0.1.11/policy.wasm
+  url: https://github.com/kubewarden/allow-privilege-escalation-psp-policy/releases/download/v0.2.0/policy.wasm
 - name: source
   url: https://github.com/kubewarden/allow-privilege-escalation-psp-policy
 provider:

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,7 +1,7 @@
 rules:
   - apiGroups: [""]
     apiVersions: ["v1"]
-    resources: ["pods"]
+    resources: ["deployment","replicaset","statefulset","daemonset","replicationcontroller","job","cronjob","pod"]
     operations: ["CREATE", "UPDATE"]
 mutating: true
 contextAware: false
@@ -13,6 +13,101 @@ annotations:
   io.kubewarden.policy.source: https://github.com/kubewarden/allow-privilege-escalation-psp-policy
   io.kubewarden.policy.license: Apache-2.0
   io.kubewarden.policy.usage: |
-    This policy works by inspecting the containers and init containers of a Pod.
+    This Kubewarden Policy is a replacement for the Kubernetes Pod Security Policy
+    that limits the usage of the [`allowPrivilegeEscalation`](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
-    If any of these containers has `allowPrivilegeEscalation` enabled, the Pod is rejected.
+    # How the policy works
+
+    This policy rejects all the Pods that have at least one container or
+    init container with the `allowPrivilegeEscalation` security context
+    enabled.
+
+    The policy can also mutate Pods to ensure they have `allowPrivilegeEscalation`
+    set to `false` whenever the user is not explicit about that.
+    This is a replacement of the `DefaultAllowPrivilegeEscalation` configuration
+    option of the original Kubernetes PSP.
+
+    # Configuration
+
+    The policy can be configured in this way:
+
+    ```yaml
+    default_allow_privilege_escalation: false
+    ```
+
+    Sets the default for the allowPrivilegeEscalation option. The default behavior without this is to allow privilege escalation so as to not break setuid binaries. If that behavior is not desired, this field can be used to default to disallow, while still permitting pods to request allowPrivilegeEscalation explicitly.
+
+    By default `default_allow_privilege_escalation` is set to `true`.
+
+    This policy can inspect Pod resources, but can also operate against "higher order"
+    Kuberenetes resource like Deployment, ReplicaSet, DaemonSet, ReplicationController,
+    Job and CronJob.
+
+    It's up to the operator to decide which kind of resources the policy is going to inspect.
+    That is done when declaring the policy.
+
+    There are pros and cons to both approaches:
+
+    - Have the policy inspect low level resources, like Pod. Different kind of Kubernetes
+      resources (be them native or CRDs) can create Pods. By having the policy target Pod
+      objects, there's the guarantee all the Pods are going to be compliant. However,
+      this could lead to some confusion among end users of the cluster: their high level
+      Kubernetes resources would be successfully created, but they would stay in a non
+      reconciled state. For example, a Deployment creating a non-compliant Pod would be
+      created, but it would never have all its replicas running. The end user would
+      have to do some debugging to finally understand why this is happening.
+    - Have the policy inspect higher order resource (e.g. Deployment): the end users
+      will get immediate feedback about the rejections. However, there's still the
+      chance that some non compliant pods are created by another high level resource
+      (be it native to Kubernetes, or a CRD).
+
+    # Examples
+
+    The following Pod will be rejected because the nginx container has
+    `allowPrivilegeEscalation` enabled:
+
+    ```yaml
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        securityContext:
+          allowPrivilegeEscalation: true
+      - name: sidecar
+        image: sidecar
+    ```
+
+    The following Pod would be blocked because one of the init containers
+    has `allowPrivilegeEscalation` enabled:
+
+    ```yaml
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+      - name: sidecar
+        image: sidecar
+      initContainers:
+      - name: init-myservice
+        image: init-myservice
+        securityContext:
+          allowPrivilegeEscalation: true
+    ```
+
+    # Obtain policy
+
+    The policy is automatically published as an OCI artifact inside of
+    [this](https://github.com/orgs/kubewarden/packages/container/package/policies%2Fpsp-allow-privilege-escalation)
+    container registry.
+
+    # Using the policy
+
+    The easiest way to use this policy is through the [kubewarden-controller](https://github.com/kubewarden/kubewarden-controller).

--- a/test_data/deployment_with_allow_privileged_escalation.json
+++ b/test_data/deployment_with_allow_privileged_escalation.json
@@ -1,0 +1,176 @@
+{
+  "dryRun": false,
+  "kind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "name": "nginx",
+  "namespace": "default",
+  "object": {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "annotations": {
+        "io.kubewarden.policy.echo.create": "true",
+        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{\"io.kubewarden.policy.echo.create\":\"true\"},\"name\":\"nginx\",\"namespace\":\"default\"},\"spec\":{\"replicas\":0,\"selector\":{\"matchLabels\":{\"app\":\"nginx\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"nginx\"}},\"spec\":{\"containers\":[{\"image\":\"nginx:latest\",\"name\":\"nginx\",\"ports\":[{\"containerPort\":80}],\"securityContext\":{\"runAsUser\":0}}]}}}}\n"
+      },
+      "creationTimestamp": "2022-09-23T13:40:09Z",
+      "generation": 1,
+      "managedFields": [
+        {
+          "apiVersion": "apps/v1",
+          "fieldsType": "FieldsV1",
+          "fieldsV1": {
+            "f:metadata": {
+              "f:annotations": {
+                ".": {},
+                "f:io.kubewarden.policy.echo.create": {},
+                "f:kubectl.kubernetes.io/last-applied-configuration": {}
+              }
+            },
+            "f:spec": {
+              "f:progressDeadlineSeconds": {},
+              "f:replicas": {},
+              "f:revisionHistoryLimit": {},
+              "f:selector": {},
+              "f:strategy": {
+                "f:rollingUpdate": {
+                  ".": {},
+                  "f:maxSurge": {},
+                  "f:maxUnavailable": {}
+                },
+                "f:type": {}
+              },
+              "f:template": {
+                "f:metadata": {
+                  "f:labels": {
+                    ".": {},
+                    "f:app": {}
+                  }
+                },
+                "f:spec": {
+                  "f:containers": {
+                    "k:{\"name\":\"nginx\"}": {
+                      ".": {},
+                      "f:image": {},
+                      "f:imagePullPolicy": {},
+                      "f:name": {},
+                      "f:ports": {
+                        ".": {},
+                        "k:{\"containerPort\":80,\"protocol\":\"TCP\"}": {
+                          ".": {},
+                          "f:containerPort": {},
+                          "f:protocol": {}
+                        }
+                      },
+                      "f:resources": {},
+                      "f:securityContext": {
+                        ".": {},
+                        "f:runAsUser": {}
+                      },
+                      "f:terminationMessagePath": {},
+                      "f:terminationMessagePolicy": {}
+                    }
+                  },
+                  "f:dnsPolicy": {},
+                  "f:restartPolicy": {},
+                  "f:schedulerName": {},
+                  "f:securityContext": {},
+                  "f:terminationGracePeriodSeconds": {}
+                }
+              }
+            }
+          },
+          "manager": "kubectl-client-side-apply",
+          "operation": "Update",
+          "time": "2022-09-23T13:40:09Z"
+        }
+      ],
+      "name": "nginx",
+      "namespace": "default",
+      "uid": "84716ca0-aa8b-4b0c-a0ca-0ad7e0c4c9c6"
+    },
+    "spec": {
+      "progressDeadlineSeconds": 600,
+      "replicas": 0,
+      "revisionHistoryLimit": 10,
+      "selector": {
+        "matchLabels": {
+          "app": "nginx"
+        }
+      },
+      "strategy": {
+        "rollingUpdate": {
+          "maxSurge": "25%",
+          "maxUnavailable": "25%"
+        },
+        "type": "RollingUpdate"
+      },
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "app": "nginx"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "image": "nginx:latest",
+              "imagePullPolicy": "Always",
+              "name": "nginx",
+              "ports": [
+                {
+                  "containerPort": 80,
+                  "protocol": "TCP"
+                }
+              ],
+              "resources": {},
+          "securityContext": {
+            "allowPrivilegeEscalation": true
+          },
+              "terminationMessagePath": "/dev/termination-log",
+              "terminationMessagePolicy": "File"
+            }
+          ],
+          "dnsPolicy": "ClusterFirst",
+          "restartPolicy": "Always",
+          "schedulerName": "default-scheduler",
+          "securityContext": {},
+          "terminationGracePeriodSeconds": 30
+        }
+      }
+    },
+    "status": {}
+  },
+  "operation": "CREATE",
+  "options": {
+    "apiVersion": "meta.k8s.io/v1",
+    "fieldManager": "kubectl-client-side-apply",
+    "kind": "CreateOptions"
+  },
+  "requestKind": {
+    "group": "apps",
+    "kind": "Deployment",
+    "version": "v1"
+  },
+  "requestResource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "resource": {
+    "group": "apps",
+    "resource": "deployments",
+    "version": "v1"
+  },
+  "uid": "8560a482-887d-49b2-8781-415d04a0dcb0",
+  "userInfo": {
+    "groups": [
+      "system:masters",
+      "system:authenticated"
+    ],
+    "username": "system:admin"
+  }
+}


### PR DESCRIPTION
## Description

Updates the policy to verify high level resources instead of Pod. This way, the resource creation will be rejected instead of rejecting the Pod creation in the deployment phase.

Fix #32 