### PR TITLE
Bump v0.2.6 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "allow-privilege-escalation-psp"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allow-privilege-escalation-psp"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,28 +4,28 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.2.5
+version: 0.2.6
 name: allow-privilege-escalation-psp
 displayName: Allow Privilege Escalation PSP
-createdAt: 2023-04-03T16:09:06.72932456Z
+createdAt: 2023-07-07T16:25:46.745596819Z
 description: Replacement for the Kubernetes Pod Security Policy that controls the allowance of privilege escalation in containers and init containers of a pod
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/allow-privilege-escalation-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.2.5
+  image: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.2.6
 keywords:
 - PSP
 - privilege escalation
 links:
 - name: policy
-  url: https://github.com/kubewarden/allow-privilege-escalation-psp-policy/releases/download/v0.2.5/policy.wasm
+  url: https://github.com/kubewarden/allow-privilege-escalation-psp-policy/releases/download/v0.2.6/policy.wasm
 - name: source
   url: https://github.com/kubewarden/allow-privilege-escalation-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.2.5
+  kwctl pull ghcr.io/kubewarden/policies/allow-privilege-escalation-psp:v0.2.6
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the Cargo and artifacthub files bumping the policy version to v0.2.6


Related to https://github.com/kubewarden/kubewarden-controller/issues/479